### PR TITLE
PasswordCheck und bcrypt fix

### DIFF
--- a/backend/Tutorial/Tutorial/Bcrypt.cs
+++ b/backend/Tutorial/Tutorial/Bcrypt.cs
@@ -650,7 +650,7 @@ namespace Bcrypt
             {
                 throw new ArgumentNullException("password");
             }
-            if (salt == null)
+            if (string.IsNullOrEmpty(salt))
             {
                 throw new ArgumentNullException("salt");
             }

--- a/backend/Tutorial/Tutorial/Datenbank.cs
+++ b/backend/Tutorial/Tutorial/Datenbank.cs
@@ -148,8 +148,7 @@ namespace Tutorial
                 password = reader.GetString("password");
             }
 
-            if (Bcrypt.BCrypt.CheckPassword(passwordinput, password)) return true;
-            return false;
+            return Bcrypt.BCrypt.CheckPassword(passwordinput, password); // Gibt ein true oder false zurück
         }
 
         //Haussystem

--- a/backend/Tutorial/Tutorial/Datenbank.cs
+++ b/backend/Tutorial/Tutorial/Datenbank.cs
@@ -139,16 +139,17 @@ namespace Tutorial
 
             using (MySqlDataReader reader = command.ExecuteReader())
             {
-                if(reader.HasRows)
+                if(!reader.HasRows)
                 {
-                    reader.Read();
-                    password = reader.GetString("password");
+                    return false;
                 }
+                
+                reader.Read();
+                password = reader.GetString("password");
             }
 
             if (Bcrypt.BCrypt.CheckPassword(passwordinput, password)) return true;
             return false;
-
         }
 
         //Haussystem


### PR DESCRIPTION
Ein kleiner fix für PasswordCheck und bcrypt.

Ich finde ein der Datei "bcrypt.cs" die Abfrage ob salt null ist durch null oder empty zu ersetzen besser da anscheinend die strings im tutorial mit "" initialisiert werden anstatt mit null falls man bcrypt noch einmal für irgendetwas benötigt hat man so vorgesorgt.